### PR TITLE
enabled reading extra netcdf variables

### DIFF
--- a/build/Qt/gcc/RHESSys/RHESSys.pro
+++ b/build/Qt/gcc/RHESSys/RHESSys.pro
@@ -17,6 +17,7 @@ QMAKE_CXXFLAGS += -fpermissive
 QMAKE_CXXFLAGS += -fopenmp
 QMAKE_CFLAGS += -fopenmp
 QMAKE_LFLAGS += -fopenmp
+
 #QMAKE_CFLAGS += -STD=C99
 
 TEMPLATE = app
@@ -27,7 +28,9 @@ DEFINES += NO_UPDATE_160419 \
            LIU_NETCDF_READER \
            CHECK_NCCLIM_DATA \
            FIND_STATION_BASED_ON_ID \
-           RUN_WITH_SPINUP_PERIOD_USING_RANDOM_CLIMATE_YEAR_DATA
+           LIU_EXTEND_CLIM_VAR \
+           LIU_EXTEND_CLIM_VAR_AND_USE_SWRAD
+
 
 SOURCES += \
     ../../../../rhessys/clim/compute_toc_wind.c \
@@ -348,7 +351,9 @@ SOURCES += \
     ../../../../util/FIRE/RanNums.cpp \
     ../../../../rhessys/hydro/compute_saturation_vapor_pressure.c \
     ../../../../rhessys/hydro/compute_vapor_pressure_deficit.c \
-    ../../../../rhessys/output/output_basin.c
+    ../../../../rhessys/output/output_basin.c \
+    ../../../../rhessys/cn/compute_fire_effects.c \
+    ../../../../rhessys/cn/update_litter_soil_mortality.c
 
 OTHER_FILES += \
     ../../../../rhessys/cycle/patch_daily_F.c,v

--- a/rhessys/cycle/zone_daily_F.c
+++ b/rhessys/cycle/zone_daily_F.c
@@ -170,6 +170,14 @@ void		zone_daily_F(
 			zone[0].Kdown_direct = zone[0].Kdown_direct_calc;
 			zone[0].Kdown_diffuse_flat = zone[0].Kdown_diffuse_flat_calc;
 			zone[0].Kdown_diffuse = zone[0].Kdown_diffuse_calc;
+#ifdef LIU_EXTEND_CLIM_VAR_AND_USE_SWRAD
+            double rsds_obs = zone[0].base_stations[0][0].daily_clim[0].surface_shortwave_rad[day] * (double)SECONDS_PER_DAY;
+            double adj = rsds_obs * 0.001 / (zone[0].Kdown_direct_flat + zone[0].Kdown_diffuse_flat);
+            zone[0].Kdown_direct        *= adj;
+            zone[0].Kdown_diffuse       *= adj;
+            zone[0].Kdown_direct_flat   *= adj;
+            zone[0].Kdown_diffuse_flat  *= adj;
+#endif
 		}
 	/* Otherwise use input Kdowns and calculate transmissivity as	*/
 	/* ratio between given and calculated, then generate cloud		*/

--- a/rhessys/include/rhessys.h
+++ b/rhessys/include/rhessys.h
@@ -651,6 +651,19 @@ typedef struct base_station_ncheader_object
         char    netcdf_tmin_varname[MAXSTR];    /* variable name for tmin in nc file */
         char    netcdf_rain_varname[MAXSTR];    /* variable name for rain in nc file */
         char    netcdf_elev_varname[MAXSTR];    /* variable name for elev in nc file */
+#ifdef LIU_EXTEND_CLIM_VAR
+        double  rhum_mult;                    /* multiplier for relative humidity to 0-1 */
+        char    netcdf_huss_filename[MAXSTR];   /* filename for specific humidity nc file */
+        char    netcdf_huss_varname[MAXSTR];    /* variable name for specific humidity in nc file */
+        char    netcdf_rmax_filename[MAXSTR];   /* filename for relative humidity max nc file */
+        char    netcdf_rmax_varname[MAXSTR];    /* variable name for relative humidity max in nc file */
+        char    netcdf_rmin_filename[MAXSTR];   /* filename for relative humidity min nc file */
+        char    netcdf_rmin_varname[MAXSTR];    /* variable name for relative humidity min in nc file */
+        char    netcdf_rsds_filename[MAXSTR];   /* filename for shortwave radiation nc file */
+        char    netcdf_rsds_varname[MAXSTR];    /* variable name for shortwave radiation in nc file */
+        char    netcdf_was_filename[MAXSTR];   /* filename for wind speed nc file */
+        char    netcdf_was_varname[MAXSTR];    /* variable name for wind speed in nc file */
+#endif
 } base_station_ncheader_object;
 /*----------------------------------------------------------*/
 /*      Define dated climate sequence                       */
@@ -756,6 +769,12 @@ struct  daily_clim_object
         double  *vpd;                           /*      Pa              */
         double  *wind;                          /*      m/s             */
         double  *wind_direction;                /*      degrees         */
+#ifdef LIU_EXTEND_CLIM_VAR
+        double  *relative_humidity_max;         /*      0 - 1                 */
+        double  *relative_humidity_min;         /*      0 - 1                 */
+        double  *surface_shortwave_rad;         /*      W m-2  daily average  */
+        double  *specific_humidity;             /*      kg/kg  daily average  */
+#endif
         };    
         
 

--- a/rhessys/init/construct_netcdf_header.c
+++ b/rhessys/init/construct_netcdf_header.c
@@ -151,6 +151,31 @@ struct base_station_ncheader_object *construct_netcdf_header (
                 strcpy(base_station_ncheader[0].netcdf_elev_varname,first);
                 base_station_ncheader[0].elevflag = 1;
             }
+#ifdef LIU_EXTEND_CLIM_VAR
+            else if (strcmp(second, "rhum_multiplier") == 0){
+                           base_station_ncheader[0].rhum_mult = atof(first);
+            } else if(strcmp(second,"netcdf_huss_filename") == 0){
+                strcpy(base_station_ncheader[0].netcdf_huss_filename,first);
+            } else if(strcmp(second,"netcdf_var_huss") == 0){
+                strcpy(base_station_ncheader[0].netcdf_huss_varname,first);
+            } else if(strcmp(second,"netcdf_rmax_filename") == 0){
+                strcpy(base_station_ncheader[0].netcdf_rmax_filename,first);
+            } else if(strcmp(second,"netcdf_var_rmax") == 0){
+                strcpy(base_station_ncheader[0].netcdf_rmax_varname,first);
+            } else if(strcmp(second,"netcdf_rmin_filename") == 0){
+                strcpy(base_station_ncheader[0].netcdf_rmin_filename,first);
+            } else if(strcmp(second,"netcdf_var_rmin") == 0){
+                strcpy(base_station_ncheader[0].netcdf_rmin_varname,first);
+            } else if(strcmp(second,"netcdf_rsds_filename") == 0){
+                strcpy(base_station_ncheader[0].netcdf_rsds_filename,first);
+            } else if(strcmp(second,"netcdf_var_rsds") == 0){
+                strcpy(base_station_ncheader[0].netcdf_rsds_varname,first);
+            } else if(strcmp(second,"netcdf_was_filename") == 0){
+                strcpy(base_station_ncheader[0].netcdf_was_filename,first);
+            } else if(strcmp(second,"netcdf_var_was") == 0){
+                strcpy(base_station_ncheader[0].netcdf_was_varname,first);
+            }
+#endif
             #ifdef LIU_NETCDF_READER
             else if (strcmp(second, "base_station_id") == 0) {
                 baseid++;

--- a/rhessys/init/destroy_base_station.c
+++ b/rhessys/init/destroy_base_station.c
@@ -65,6 +65,12 @@ void destroy_base_station( struct command_line_object *command_line,
 	if(base_station[0].daily_clim[0].lapse_rate_tmax!=NULL) free( base_station[0].daily_clim[0].lapse_rate_tmax);
 	if(base_station[0].daily_clim[0].lapse_rate_tmin!=NULL) free( base_station[0].daily_clim[0].lapse_rate_tmin);
 	if(base_station[0].daily_clim[0].daytime_rain_duration!=NULL) free( base_station[0].daily_clim[0].daytime_rain_duration);
+#ifdef LIU_EXTEND_CLIM_VAR
+    if(base_station[0].daily_clim[0].relative_humidity_max!=NULL) free( base_station[0].daily_clim[0].relative_humidity_max);
+    if(base_station[0].daily_clim[0].relative_humidity_min!=NULL) free( base_station[0].daily_clim[0].relative_humidity_min);
+    if(base_station[0].daily_clim[0].specific_humidity!=NULL) free( base_station[0].daily_clim[0].specific_humidity);
+    if(base_station[0].daily_clim[0].surface_shortwave_rad!=NULL) free( base_station[0].daily_clim[0].surface_shortwave_rad);
+#endif
 	free( base_station[0].daily_clim );
 	free( base_station[0].monthly_clim );
 	free( base_station[0].hourly_clim[0].rain.seq);


### PR DESCRIPTION
Erin,

I enabled the code to read more climate variables (rhum_max, rhum_min, swrad, specific humidity (not being used yet!), and wind speed). In your make file, you may need add macros LIU_EXTEND_CLIM_VAR and LIU_EXTEND_CLIM_VAR_AND_USE_SWRAD (if you want observed shortwave radiation; otherwise, do not add this macro).

-Min